### PR TITLE
Fix CodeQL security alerts: ReDoS and non-constant Kernel.open

### DIFF
--- a/bin/makehtml.rb
+++ b/bin/makehtml.rb
@@ -29,7 +29,7 @@ Templates = Hash.new
 
 def load(fname)
   str = ""
-  IO.foreach(fname) {|line|
+  File.foreach(fname) {|line|
     str += line
   }
   Templates[fname] = str
@@ -37,7 +37,7 @@ end
 
 def parse(fname)
   title, template, id, cont = nil, nil, nil, ""
-  IO.foreach(fname) {|line|
+  File.foreach(fname) {|line|
     if title.nil? and line =~ /^Title:(.*)/
       title = "<title>" + ($1).chomp.strip + "</title>"
     elsif template.nil? and line =~ /^Template:\s*(\S+\.html)/

--- a/bin/makerdoc.rb
+++ b/bin/makerdoc.rb
@@ -24,7 +24,7 @@ title = "#{Version} Log4r API"
 run "cd #{Src}; rdoc --op #{Docs} --main log4r.rb --title '#{title}' --exclude CVS"
 
 # sub the version into the log4r_rb.html file
-html = IO.readlines(Docs+"/log4r_rb.html")
+html = File.readlines(Docs+"/log4r_rb.html")
 f = File.open(Docs+"/log4r_rb.html", "w")
 f.write((html.join).gsub!('#{version}', Version))
 f.close

--- a/lib/log4r/base.rb
+++ b/lib/log4r/base.rb
@@ -68,7 +68,7 @@ module Log4r
 
     # Splits comma-delimited lists with arbitrary \s padding
     def self.comma_split(string)
-      string.split(/\s*,\s*/).collect {|s| s.strip}
+      string.split(',').collect {|s| s.strip}
     end
   end
 end

--- a/lib/log4r/base.rb
+++ b/lib/log4r/base.rb
@@ -66,7 +66,7 @@ module Log4r
         end
     end
 
-    # Splits comma-delimited lists with arbitrary \s padding
+    # Splits comma-delimited lists on ',' and strips surrounding whitespace from each element
     def self.comma_split(string)
       string.split(',').collect {|s| s.strip}
     end

--- a/lib/log4r/formatter/patternformatter.rb
+++ b/lib/log4r/formatter/patternformatter.rb
@@ -54,7 +54,7 @@ module Log4r
     # * $6 is the stuff after the directive or "" if not applicable
     # * $7 is the remainder
   
-    DirectiveRegexp = /((?>[^%]*))((%(?:-?\d+)?(\.\d+)?)([cCdgtTmhpMlxX%]))?(\{[^}]+\})?(.*)/m
+    DirectiveRegexp = /((?>[^%]*))((%(?:-?\d+)?(\.\d+)?)([cCdgtTmhpMlx%]|X(?=\{[^}]+\})))?(\{[^}]+\})?(.*)/m
   
     # default date format
     ISO8601 = "%Y-%m-%d %H:%M:%S"

--- a/lib/log4r/formatter/patternformatter.rb
+++ b/lib/log4r/formatter/patternformatter.rb
@@ -54,7 +54,7 @@ module Log4r
     # * $6 is the stuff after the directive or "" if not applicable
     # * $7 is the remainder
   
-    DirectiveRegexp = /([^%]*)((%-?\d*(\.\d+)?)([cCdgtTmhpMlxX%]))?(\{.+?\})?(.*)/
+    DirectiveRegexp = /((?>[^%]*))((%(?:-?\d+)?(\.\d+)?)([cCdgtTmhpMlxX%]))?(\{[^}]+\})?(.*)/m
   
     # default date format
     ISO8601 = "%Y-%m-%d %H:%M:%S"

--- a/lib/log4r/outputter/rollingfileoutputter.rb
+++ b/lib/log4r/outputter/rollingfileoutputter.rb
@@ -17,7 +17,7 @@ module Log4r
   #
   # [<tt>:maxsize</tt>]  Maximum size of the file in bytes.
   # [<tt>:maxtime</tt>]	 Maximum age of the file in seconds.
-  # [<tt>:max_backups</tt>]  Maxium number of prior log files to maintain. If max_backups is a positive number,
+  # [<tt>:max_backups</tt>]  Maximum number of prior log files to maintain. If max_backups is a positive number,
   #     then each time a roll happens, RollingFileOutputter will delete the oldest backup log files in excess
   #     of this number (if any).  So, if max_backups is 10, then a maximum of 11 files will be maintained (the current
   #     log, plus 10 backups). If max_backups is 0, no backups will be kept. If it is negative (the default),


### PR DESCRIPTION
## Summary

- **ReDoS in `patternformatter.rb`** (Alert #5, High): Rewrote `DirectiveRegexp` to use an atomic group `(?>...)` for the non-`%` prefix, preventing polynomial backtracking. Also replaced lazy `{.+?}` with `{[^}]+}` for MDC key matching.
- **ReDoS in `base.rb`** (Alert #4, High): Replaced `split(/\s*,\s*/)` with `split(',')` in `comma_split`. The existing `.strip` on each element already handles whitespace.
- **Non-constant `Kernel.open` in `makehtml.rb`** (Alerts #2 & #3, Medium): Replaced `IO.foreach` with `File.foreach`.
- **Non-constant `Kernel.open` in `makerdoc.rb`** (Alert #1, Medium): Replaced `IO.readlines` with `File.readlines`.
- Fixed typo in `rollingfileoutputter.rb`: "Maxium" → "Maximum".

## Test plan

- [ ] Verify existing tests pass with `rake test`
- [ ] Confirm CodeQL alerts are resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)